### PR TITLE
Update path.js

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -1,5 +1,6 @@
 const { URLSearchParams } = require("url");
 const { OpenApiAnnotation, OpenApiParamIn } = require("./constants");
+const { CapError } = require("./error");
 
 const PLACEHOLDER_REGEX = /(?<=\{)(.*)(?=\})/g;
 


### PR DESCRIPTION
fix(CapError): Add import to `CapError`. This fixes issue #8.